### PR TITLE
Store code cov percentage for badge display and flip pypi pointer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ jobs:
     - name: Build and publish
       env:
         TWINE_USERNAME: "__token__"
-        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         export PROTOC=$(pwd)/bin/protoc
         export VERSION=$(./GENVER --pep440)
         HOME=$(pwd) python setup.py sdist bdist_wheel
         ls -ltr dist/
-        python -m twine upload --repository-url=https://test.pypi.org/legacy/ dist/*
+        python -m twine upload dist/*
 
     - name: Bump VERSION file and commit 
       run: |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 <p align="center"><img src="docs/_static/img/logo.png" width=400 /></p>
 
-[![pipeline status](https://gitlab.int.petuum.com/internal/scalable-ml/autodist/badges/master/pipeline.svg)](https://gitlab.int.petuum.com/internal/scalable-ml/autodist/commits/master)
-[![coverage report](https://gitlab.int.petuum.com/internal/scalable-ml/autodist/badges/master/coverage.svg)](https://gitlab.int.petuum.com/internal/scalable-ml/autodist/commits/master)
+[![pipeline status](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/master/lastBuild/api/json&label=build&query=$.result&color=important)](https://github.com/petuum/autodist/commits/master)
+[![coverage report](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/master/lastSuccessfulBuild/artifact/coverage-report/jenkinscovdata.json&label=coverage&query=$.total_coverage_pct&color=important)](https://github.com/petuum/autodist/commits/master)
 
 [Documentation](http://10.20.41.55:8080) |
 [Examples](https://github.com/petuum/autodist/tree/master/examples/benchmark)


### PR DESCRIPTION
### Overview

Creates the `build` and `coverage` badges on README.md

- **build** badge is taken from `https://jenkins.petuum.io/job/AutoDist/job/master/lastBuild/api/json` based on its ".result" key
- **coverage** badge is taken from `https://jenkins.petuum.io/job/AutoDist/job/master/lastSuccessfulBuild/artifact/coverage-report/jenkinscovdata.json` based on its ".total_coverage_pct" key

This PR adds the `coverage-report/jenkinscovdata.json` artifact so it can be seen (so it will be available to `master` after merge)

### Test Results

1. Commented out some tests and left only a small one
2. Pushed branch and it triggered at https://jenkins.petuum.io/job/AutoDist/job/badge-storage-and-pypi-flip/4/
3. I verified https://jenkins.petuum.io/job/AutoDist/job/badge-storage-and-pypi-flip/4/artifact/coverage-report/jenkinscovdata.json was created 
4. Badge for the test was queried for via this call: [![coverage report](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/badge-storage-and-pypi-flip/4/artifact/coverage-report/jenkinscovdata.json&label=coverage&query=$.total_coverage_pct&color=important)](https://github.com/petuum/autodist/commits/master)