### PR TITLE
Disable concurrent builds per branch, change default badge color, and remove unrequired dep

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ def myflag = false
 
 pipeline {
     options {
+        disableConcurrentBuilds()
         timeout(time: 2, unit: 'HOURS')
     }
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 <p align="center"><img src="docs/_static/img/logo.png" width=400 /></p>
 
-[![pipeline status](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/master/lastBuild/api/json&label=build&query=$.result&color=important)](https://github.com/petuum/autodist/commits/master)
-[![coverage report](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/master/lastSuccessfulBuild/artifact/coverage-report/jenkinscovdata.json&label=coverage&query=$.total_coverage_pct&color=important)](https://github.com/petuum/autodist/commits/master)
+[![pipeline status](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/master/lastCompletedBuild/api/json&label=build&query=$.result&color=informational)](https://github.com/petuum/autodist/commits/master)
+[![coverage report](https://img.shields.io/badge/dynamic/json?url=https://jenkins.petuum.io/job/AutoDist/job/master/lastSuccessfulBuild/artifact/coverage-report/jenkinscovdata.json&label=coverage&query=$.total_coverage_pct&color=9cf)](https://github.com/petuum/autodist/commits/master)
 
 [Documentation](https://petuum.github.io/autodist) |
 [Examples](https://github.com/petuum/autodist/tree/master/examples/benchmark)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
         "protobuf==3.11.0",
         "pyyaml",
         # "tensorflow-gpu>=1.15,<=2.1",  # TF Version dynamic check at importing
-        "gast==0.2.2",
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
### Overview

(1) With limited GPU slaves, no reason to have concurrent builds per branch, can be sequential.

(2) Also changed the badge schemes:

- **build**; color goes from "important" to "informational" by default, and we switch to badge of last completed build
- **coverage**; default color changed to 9cf hex

(3) Per @pw2393 , removed `gast==0.2.2` which is not an autodist dependency anymore