### PR TITLE
Autodist on Ray using RaySGD API

### DIFF
--- a/autodist/__init__.py
+++ b/autodist/__init__.py
@@ -26,7 +26,8 @@ from .utils import logging
 logging.set_verbosity(ENV.AUTODIST_MIN_LOG_LEVEL.val)
 
 # Enforce abspath
-if sys.argv and os.path.exists(sys.argv[0]) and not os.path.isabs(sys.argv[0]):
+if sys.argv and os.path.exists(sys.argv[0]) and not os.path.isabs(sys.argv[0]) \
+        and "ray" not in sys.modules:
     logging.error('AutoDist requires the script path "{}" to be an absolute path to be shared across workers. '
                   'Now exit.'.format(sys.argv[0]))
     sys.exit(1)

--- a/autodist/autodist.py
+++ b/autodist/autodist.py
@@ -66,10 +66,8 @@ class _AutoDistInterface:
         set_default_autodist(self)
         if resource_spec_file is not None:
             self._resource_spec = ResourceSpec(resource_file=resource_spec_file)
-            self._on_ray = False
         else:
             self._resource_spec = resource_spec
-            self._on_ray = True  # Autodist running on Ray
         self._strategy_builder = strategy_builder or PSLoadBalancing()
 
         self._original_graph_item = None
@@ -125,7 +123,7 @@ class _AutoDistInterface:
 
     def _setup(self, strategy):
         """Prepare for the execution."""
-        if not bool(ENV.AUTODIST_WORKER.val) and not self._on_ray:
+        if not bool(ENV.AUTODIST_WORKER.val) and not ENV.AUTODIST_RAY_BACKEND.val:
             # we should only have one single coordinator for one single AutoDist() instance scope,
             # even though we could have multiple strategies.
             self._coordinator = Coordinator(strategy=strategy, cluster=self._cluster)

--- a/autodist/autodist.py
+++ b/autodist/autodist.py
@@ -37,8 +37,6 @@ from autodist.strategy import base
 from autodist.strategy.ps_lb_strategy import PSLoadBalancing
 from autodist.utils import logging
 
-IS_AUTODIST_WORKER = bool(ENV.AUTODIST_WORKER.val)
-IS_AUTODIST_CHIEF = not IS_AUTODIST_WORKER
 
 _DEFAULT_AUTODIST = {}
 
@@ -64,9 +62,14 @@ class _AutoDistInterface:
     Ancestor of _V1Graph, _V2Graph, and _V2Eager -- the different ways to run TF code.
     """
 
-    def __init__(self, resource_spec_file, strategy_builder=None):
+    def __init__(self, resource_spec_file=None, strategy_builder=None, resource_spec=None, strategy=None):
         set_default_autodist(self)
-        self._resource_spec = ResourceSpec(resource_file=resource_spec_file)
+        if resource_spec_file is not None:
+            self._resource_spec = ResourceSpec(resource_file=resource_spec_file)
+            self._on_ray = False
+        else:
+            self._resource_spec = resource_spec
+            self._on_ray = True  # Autodist running on Ray
         self._strategy_builder = strategy_builder or PSLoadBalancing()
 
         self._original_graph_item = None
@@ -76,6 +79,7 @@ class _AutoDistInterface:
 
         self._cluster: Cluster = SSHCluster(self._resource_spec)  # which can be also defined with strategy
         self._coordinator: Coordinator
+        self._strategy = strategy  # Directly passed strategy to Ray workers if not None
 
     @tf_contextlib.contextmanager
     def _scope(self):
@@ -99,9 +103,11 @@ class _AutoDistInterface:
 
     def _build_or_load_strategy(self):
         self._original_graph_item.prepare()
-        if IS_AUTODIST_CHIEF:
+        if not bool(ENV.AUTODIST_WORKER.val):
             s = self.build_strategy()
             s.serialize()
+        elif self._strategy is not None:
+            s = self._strategy
         else:
             strategy_id = ENV.AUTODIST_STRATEGY_ID.val
             assert strategy_id
@@ -119,7 +125,7 @@ class _AutoDistInterface:
 
     def _setup(self, strategy):
         """Prepare for the execution."""
-        if IS_AUTODIST_CHIEF:
+        if not bool(ENV.AUTODIST_WORKER.val) and not self._on_ray:
             # we should only have one single coordinator for one single AutoDist() instance scope,
             # even though we could have multiple strategies.
             self._coordinator = Coordinator(strategy=strategy, cluster=self._cluster)
@@ -148,6 +154,7 @@ class _GraphModeInterface(_AutoDistInterface):
         self._transformed_graph_item = graph_transformer.transform()
         self._remapper = Remapper(graph_transformer, self._transformed_graph_item)
         self._built = self._original_graph_item.graph.as_graph_def()
+        self._strategy = strategy
 
     def is_built(self):
         """

--- a/autodist/const.py
+++ b/autodist/const.py
@@ -80,6 +80,7 @@ class ENV(Enum):
     AUTODIST_INTERNAL_TF = auto(), lambda v: (v or "False") == "True"       # noqa: E731
     SYS_DATA_PATH = auto(), lambda v: v or ""                         # noqa: E731
     SYS_RESOURCE_PATH = auto(), lambda v: v or ""                     # noqa: E731
+    AUTODIST_RAY_BACKEND = auto(), lambda v: True if v == "True" else False
 
     @property
     def val(self):

--- a/autodist/const.py
+++ b/autodist/const.py
@@ -80,7 +80,7 @@ class ENV(Enum):
     AUTODIST_INTERNAL_TF = auto(), lambda v: (v or "False") == "True"       # noqa: E731
     SYS_DATA_PATH = auto(), lambda v: v or ""                         # noqa: E731
     SYS_RESOURCE_PATH = auto(), lambda v: v or ""                     # noqa: E731
-    AUTODIST_RAY_BACKEND = auto(), lambda v: True if v == "True" else False
+    AUTODIST_RAY_BACKEND = auto(), lambda v: True if v == "True" else False  # noqa: E731
 
     @property
     def val(self):

--- a/autodist/ray/__init__.py
+++ b/autodist/ray/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .backend import TFTrainer
+from .backend import TFRunner
+

--- a/autodist/ray/__init__.py
+++ b/autodist/ray/__init__.py
@@ -14,4 +14,3 @@
 
 from .backend import TFTrainer
 from .backend import TFRunner
-

--- a/autodist/ray/backend.py
+++ b/autodist/ray/backend.py
@@ -102,8 +102,7 @@ class TFRunner:
     def step(self):
         """Take one training step."""
         self._epoch += 1
-        with self._g.as_default(), self._autodist.scope():
-            return self._session.run(self._fetches)
+        return self._session.run(self._fetches)
 
     def get_strategy(self):
         """Fetch the current strategy."""

--- a/autodist/ray/backend.py
+++ b/autodist/ray/backend.py
@@ -161,7 +161,7 @@ class TFTrainer:
                 # Make sure we spawn one server per Ray node
                 # Give it all the GPUs on that node
                 server = TFServer.options(resources={f"node:{node_ip}": 0.01},
-                                          num_gpus=gpu_devices.get('node_ip', 0)).remote()
+                                          num_gpus=len(gpu_devices.get(node_ip, []))).remote()
                 servers.append(server)
                 server.launch.remote(cluster_spec, 
                                      job_name, 

--- a/autodist/ray/backend.py
+++ b/autodist/ray/backend.py
@@ -194,17 +194,9 @@ class TFTrainer:
 
         ray.get([replica.step.remote() for replica in self._replicas])
 
-    def validate(self):
-        pass
-
     def shutdown(self):
         for server in self._servers:
             ray.kill(server)
         for replica in self._replicas:
             ray.kill(replica)
 
-    def save(self):
-        pass
-
-    def restore(self):
-        pass

--- a/autodist/ray/backend.py
+++ b/autodist/ray/backend.py
@@ -1,0 +1,157 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import ray
+import tensorflow as tf
+import tensorflow.compat.v1 as v1
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.training.server_lib import ClusterSpec, Server
+
+from autodist import AutoDist
+from autodist.const import ENV, DEFAULT_PORT_RANGE, DEFAULT_WORKING_DIR, DEFAULT_GROUP_LEADER
+from autodist.resource_spec import ResourceSpec
+
+
+@ray.remote
+class TFServerActor(object):
+    def launch(self, cluster_spec, job_name, task_index, cpu_device_num):
+        experimental = config_pb2.ConfigProto.Experimental(
+            collective_nccl=False,
+            collective_group_leader=DEFAULT_GROUP_LEADER)
+        s = Server(
+            ClusterSpec(cluster_spec),
+            job_name=job_name,
+            task_index=task_index,
+            config=config_pb2.ConfigProto(
+                experimental=experimental,
+                device_count={"CPU": cpu_device_num},
+                inter_op_parallelism_threads=0,
+                intra_op_parallelism_threads=0,
+            )
+        )
+        s.join()
+
+
+class TFRunner:
+    def __init__(self, model, data_creator, train_step, env, resource_spec, strategy):
+        for k, v in env.items():
+            if type(v) == bool:
+                os.environ[k] = "True" if v else "False"
+            else:
+                os.environ[k] = v
+
+        self.autodist = AutoDist(resource_spec=resource_spec,
+                                 strategy_builder=strategy)
+
+        self.g = v1.Graph()
+        with self.g.as_default(), self.autodist.scope():
+            self.fetches = train_step(model(), *data_creator())
+            self.session = self.autodist.create_distributed_session()
+
+    def step(self):
+        with self.g.as_default(), self.autodist.scope():
+            l, t, b = self.session.run(self.fetches)
+            print(f"loss: {l}  b:{b}")
+
+    def get_strategy_id(self):
+        pass
+
+
+class TFTrainer:
+    def __init__(self, model, data_creator, train_step, strategy):
+        self._resource_spec = ResourceSpec(resource_info=self._get_resource_info())
+        self._cluster_spec = self._get_default_cluster_spec(self._resource_spec)
+        self._servers = []
+        self._workers = []
+
+        print(self._cluster_spec)
+        for job_name, tasks in self._cluster_spec.items():
+            for task_index, full_address in enumerate(tasks):
+                node_ip, _ = full_address.split(':')
+                server = TFServerActor.options(resources={f"node:{node_ip}": 0.01},
+                                               num_cpus=1).remote()
+                self._servers.append(server)
+                server.launch.remote(self._cluster_spec, job_name, task_index, 1)
+
+        for job_name, tasks in self._cluster_spec.items():
+            for task_index, full_address in enumerate(tasks):
+                node_ip, _ = full_address.split(':')
+                Runner = ray.remote(resources={f"node:{node_ip}": 0.01},
+                                    num_cpus=1)(TFRunner)
+                ischief = node_ip == ray._private.services.get_node_ip_address()
+                env = {
+                    ENV.AUTODIST_WORKER.name: "" if ischief else node_ip,
+                    #ENV.AUTODIST_STRATEGY_ID.name: "20210224T233038M775422",
+                    ENV.AUTODIST_STRATEGY_ID.name: "",
+                    ENV.AUTODIST_MIN_LOG_LEVEL.name: ENV.AUTODIST_MIN_LOG_LEVEL.val,
+                    ENV.AUTODIST_IS_TESTING.name: ENV.AUTODIST_IS_TESTING.val,
+                    ENV.AUTODIST_PATCH_TF.name: ENV.AUTODIST_PATCH_TF.val,
+                    ENV.AUTODIST_INTERNAL_TF.name: ENV.AUTODIST_INTERNAL_TF.val,
+                    ENV.SYS_DATA_PATH.name: ENV.SYS_DATA_PATH.val,
+                    ENV.SYS_RESOURCE_PATH.name: ENV.SYS_RESOURCE_PATH.val,
+                    #'AUTODIST_RESOURCE_SPEC': self._resource_spec,
+                    #'val': property(lambda x: x.value)
+                }
+
+                runner = Runner.remote(model, data_creator, train_step, env, self._resource_spec, strategy)
+                self._workers.append(runner)
+
+    @staticmethod
+    def _get_default_cluster_spec(resource_spec: ResourceSpec):
+        """Create list of workers from the resource spec with semi-arbitrarily chosen ports."""
+        return {
+            'worker': [f'{node}:{next(DEFAULT_PORT_RANGE)}'
+                        for node in sorted(resource_spec.nodes, reverse=True)]
+        }
+
+    def _get_resource_info(self):
+        cpu_list = []
+        for node in ray.nodes():
+            node_ip = node["NodeManagerAddress"]
+            cpu_count = node["Resources"].get("CPU")
+            if not cpu_count or not node["Alive"]:
+               continue
+            cpu_list.append((cpu_count, node_ip))
+
+        chief_address = ray._private.services.get_node_ip_address()
+
+        resource_info = {}
+        resource_info["nodes"] = []
+        for cpu_count, node_ip in cpu_list:
+            node = {"address": node_ip, "cpus": [0]}
+            if node_ip == chief_address:
+                node["chief"] = True
+            resource_info["nodes"].append(node)
+        sorted(resource_info["nodes"], key=lambda x: x.get("chief", False))
+        return resource_info
+
+    def train(self):
+        """Runs a training epoch."""
+        ray.get([worker.step.remote() for worker in self._workers])
+
+    def validate(self):
+        pass
+
+    def shutdown(self):
+        for server, worker in zip(self._servers, self._workers):
+            ray.kill(worker)
+            ray.kill(server)
+
+    def save(self):
+        pass
+
+    def restore(self):
+        pass

--- a/autodist/resource_spec.py
+++ b/autodist/resource_spec.py
@@ -62,6 +62,7 @@ class ResourceSpec:
 
         Args:
             resource_file (string, optional): path to the file containing the resource info. Defaults to None.
+            resource_info (optional): resource_info object, used if resource_file is None
         """
         # protected properties
         self.__devices = dict()

--- a/autodist/resource_spec.py
+++ b/autodist/resource_spec.py
@@ -22,6 +22,7 @@ import paramiko
 
 from autodist.utils import logging
 from autodist.utils.network import is_loopback_address, is_local_address
+from autodist.const import ENV
 
 
 class Connectivity(Enum):
@@ -210,7 +211,8 @@ class ResourceSpec:
             gpu = DeviceSpec(host_address, host_cpu, DeviceType.GPU, gpu_index)
             self._add_device(gpu)
         self.__ssh_group[host_address] = node.get('ssh_config')
-        if self.__ssh_group[host_address] is None and self.__chief_address != host_address:
+        if self.__ssh_group[host_address] is None and self.__chief_address != host_address \
+                and not ENV.AUTODIST_RAY_BACKEND.val:
             raise ValueError("Need to define SSH groups for all non-chief nodes.")
         # handle network bandwidth (optional)
         if node.get('network_bandwidth'):

--- a/docs/usage/tutorials/save-restore.md
+++ b/docs/usage/tutorials/save-restore.md
@@ -114,7 +114,7 @@ from autodist.autodist import IS_AUTODIST_CHIEF
 # Some training code
 ...
 
-if IS_AUTODIST_CHIEF:
+if IS_AUTODIST_CHIEF():
     saver.save(session, checkpoint_name, global_step=epoch)
     print('Checkpoint saved at {%s}' % checkpoint_name)
 else:

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -18,6 +18,19 @@ The instruction for generating the training data and setting up the pre-trained 
 ```
 python ${REAL_SCRIPT_PATH}/bert.py -input_files=${REAL_DATA_PATH}/sample_data_tfrecord/*.tfrecord --bert_config_file=${REAL_DATA_PATH}/uncased_L-24_H-1024_A-16/bert_config --num_train_epochs=1 --learning_rate=5e-5 --steps_per_loop=20 --autodist_strategy=$AUTODIST_STRATEGY
 ```
+##### Running BERT on Ray backend
+Autodist can be used with Ray with the help of the RaySGD API. To start a ray cluster, first start the head node
+```
+ray start --head --port 6379 --include-dashboard=false
+```
+and subsequently attach any other nodes to the head node. The training job can then be started by running
+```
+python bert_ray.py --input_files=data/*.tfrecord --bert_config_file=bert_config.json
+```
+where `data/` has all the pretraining data and `bert_config.json` is the configuration file. This will submit the job to the local Ray cluster (`address='auto'`). Use the `--address` argument if you are targeting a different cluster. The `data/` has to be present on all the nodes of the cluster at the same path. The example supports all other arguments from the base implementation like `--autodist_strategy`.
+
+Few caveats: During execution on some platforms the TensorFlow servers might complain about too many open files. You can get rid of the errors by setting a higher open file handle limit with  `ulimit -n 1064` on all nodes before starting the Ray cluster. 
+To use a custom CUDA path, export it before starting the Ray cluster processes.
 
 #### Neural Collaborative Filtering (NCF) 
 The instruction for generating the training data can be found following [this link](https://github.com/tensorflow/models/tree/master/official/recommendation).

--- a/examples/benchmark/bert_ray.py
+++ b/examples/benchmark/bert_ray.py
@@ -1,0 +1,200 @@
+# Copyright 2020 Petuum, Inc. All Rights Reserved.
+#
+# It includes the derived work based on:
+#
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import yaml
+import os
+import sys
+import ray
+import tensorflow as tf
+from absl import app
+from absl import flags
+from absl import logging
+
+from utils.logs import logger
+from utils.misc import keras_utils
+
+from utils import bert_modeling as modeling
+from utils import bert_models
+from utils import common_flags
+from utils import input_pipeline
+from utils import bert_utils
+from utils import ray_utils
+
+#########################################################################
+# Import AutoDist and Strategy
+from autodist import AutoDist
+from autodist.strategy.all_reduce_strategy import AllReduce
+from autodist.strategy.ps_strategy import PS
+from autodist.strategy.ps_lb_strategy import PSLoadBalancing
+from autodist.strategy.parallax_strategy import Parallax
+from autodist.strategy.partitioned_ps_strategy import PartitionedPS
+#########################################################################
+
+flags.DEFINE_string(
+    'input_files',
+    None,
+    'File path to retrieve training data for pre-training.')
+flags.DEFINE_integer(
+    'max_seq_length', 128,
+    'The maximum total input sequence length after WordPiece tokenization. '
+    'Sequences longer than this will be truncated, and sequences shorter '
+    'than this will be padded.')
+flags.DEFINE_integer('max_predictions_per_seq', 20,
+                     'Maximum predictions per sequence_output.')
+flags.DEFINE_integer('train_batch_size', 2, 'Total batch size for training.')
+flags.DEFINE_integer('chunk_size', 256, 'The chunk size for training.')
+flags.DEFINE_integer('num_steps_per_epoch', 1000,
+                     'Total number of training steps to run per epoch.')
+flags.DEFINE_string(
+    name='autodist_strategy',
+    default='PS',
+    help='the autodist strategy')
+flags.DEFINE_boolean(
+    name='autodist_patch_tf',
+    default=True,
+    help='AUTODIST_PATCH_TF')
+
+flags.DEFINE_boolean(name='proxy', default=True, help='turn on off the proxy')
+
+
+common_flags.define_common_bert_flags()
+
+FLAGS = flags.FLAGS
+
+
+def get_pretrain_dataset_fn(input_file_pattern, seq_length,
+                            max_predictions_per_seq, global_batch_size,
+                            num_replicas_in_sync):
+    """Returns input dataset from input file string."""
+    def _dataset_fn(ctx=None):
+        """Returns tf.data.Dataset for distributed BERT pretraining."""
+        input_patterns = input_file_pattern.split(',')
+        batch_size = int(global_batch_size / num_replicas_in_sync)
+        train_dataset = input_pipeline.create_pretrain_dataset(
+            input_patterns,
+            seq_length,
+            max_predictions_per_seq,
+            batch_size,
+            is_training=True)
+        return train_dataset
+
+    return _dataset_fn
+
+
+def get_loss_fn(loss_factor=1.0):
+    """Returns loss function for BERT pretraining."""
+
+    def _bert_pretrain_loss_fn(unused_labels, losses, **unused_args):
+        return tf.keras.backend.mean(losses) * loss_factor
+
+    return _bert_pretrain_loss_fn
+
+
+def run_customized_training(strategy,
+                            bert_config,
+                            max_seq_length,
+                            max_predictions_per_seq,
+                            model_dir,
+                            steps_per_epoch,
+                            steps_per_loop,
+                            epochs,
+                            initial_lr,
+                            input_files,
+                            train_batch_size):
+    def _get_pretrain_model():
+        """Gets a pretraining model."""
+        pretrain_model, core_model = bert_models.pretrain_model(
+            bert_config, max_seq_length, max_predictions_per_seq)
+
+        pretrain_model.optimizer = tf.optimizers.Adam(lr=initial_lr)
+        return pretrain_model, core_model
+
+    time_callback = keras_utils.TimeHistory(
+        train_batch_size * steps_per_loop, 1)
+
+    ray.init(address="auto")
+
+    train_input_fn = get_pretrain_dataset_fn(input_files, max_seq_length,
+                                             max_predictions_per_seq,
+                                             train_batch_size,
+                                             len(ray.nodes()))
+
+    ray_utils.run_ray_job(strategy=strategy,
+                          model_fn=_get_pretrain_model,
+                          loss_fn=get_loss_fn(loss_factor=1.0),
+                          model_dir=model_dir,
+                          train_input_fn=train_input_fn,
+                          steps_per_epoch=steps_per_epoch,
+                          steps_per_loop=steps_per_loop,
+                          epochs=epochs,
+                          sub_model_export_name='pretrained/bert_model',
+                          custom_callbacks=[time_callback])
+
+    return None
+
+
+def run_bert_pretrain(strategy, gpu_num=1, node_num=1):
+    """Runs BERT pre-training."""
+
+    bert_config = modeling.BertConfig.from_json_file(FLAGS.bert_config_file)
+    logging.info(
+        'Training using customized training loop TF 2.0 with distrubuted'
+        'strategy.')
+
+    return run_customized_training(
+        strategy,
+        bert_config,
+        FLAGS.max_seq_length,
+        FLAGS.max_predictions_per_seq,
+        FLAGS.model_dir,
+        FLAGS.num_steps_per_epoch,
+        FLAGS.steps_per_loop,
+        FLAGS.num_train_epochs,
+        FLAGS.learning_rate,
+        FLAGS.input_files,
+        FLAGS.train_batch_size * 2)
+
+
+def main(_):
+    assert tf.version.VERSION.startswith('2.')
+
+    if not FLAGS.model_dir:
+        FLAGS.model_dir = '/tmp/bert/'
+
+    #########################################################################
+    # Construct AutoDist with ResourceSpec for Different Strategies
+    if FLAGS.autodist_patch_tf:
+        os.environ['AUTODIST_PATCH_TF'] = 'True'
+    else:
+        os.environ['AUTODIST_PATCH_TF'] = 'False'
+
+    logdir = '/tmp/logs'
+    if not os.path.exists(logdir):
+        os.makedirs(logdir)
+
+    # start running
+    run_bert_pretrain(PS())
+
+
+if __name__ == '__main__':
+    logging.set_verbosity(logging.INFO)
+    app.run(main)

--- a/examples/benchmark/bert_ray.py
+++ b/examples/benchmark/bert_ray.py
@@ -72,6 +72,10 @@ flags.DEFINE_boolean(
     name='autodist_patch_tf',
     default=True,
     help='AUTODIST_PATCH_TF')
+flags.DEFINE_string(
+    'address',
+    'auto',
+    'IP address of the Ray head node')
 
 flags.DEFINE_boolean(name='proxy', default=True, help='turn on off the proxy')
 
@@ -79,8 +83,6 @@ flags.DEFINE_boolean(name='proxy', default=True, help='turn on off the proxy')
 common_flags.define_common_bert_flags()
 
 FLAGS = flags.FLAGS
-
-
 
 
 def get_pretrain_dataset_fn(input_file_pattern, seq_length,
@@ -177,7 +179,7 @@ def main(_):
     assert tf.version.VERSION.startswith('2.')
 
     if not FLAGS.model_dir:
-        FLAGS.model_dir = '/tmp/bert/'
+        FLAGS.model_dir = "/tmp/ckpt/"
 
     #########################################################################
     # Construct AutoDist with ResourceSpec for Different Strategies
@@ -201,7 +203,7 @@ def main(_):
     if not os.path.exists(logdir):
         os.makedirs(logdir)
 
-    ray.init(address="auto")
+    ray.init(address=FLAGS.address)
     num_nodes = len(ray.nodes())
     num_gpus_per_node = max(1, ray.nodes()[0]['Resources'].get('GPU', 0))
     

--- a/examples/benchmark/utils/ray_utils.py
+++ b/examples/benchmark/utils/ray_utils.py
@@ -20,7 +20,6 @@ import ray
 import numpy as np
 import tensorflow as tf
 
-from autodist.strategy import PS, PSLoadBalancing, PartitionedPS, AllReduce, Parallax
 from autodist.ray import TFTrainer, TFRunner
 
 def run_ray_job(strategy,
@@ -75,11 +74,12 @@ def run_ray_job(strategy,
 
     trainer = TFTrainer(strategy, _replicated_step, model_fn, input_fn)
 
-    for epoch in range(2):
+    for epoch in range(epochs):
         per_replica = trainer.train()
-        for host, output in per_replica.items():
-            _, l = output
-            print(f"node:{host}\tloss: {l}")
+        avg_loss = sum(val[1] for val in per_replica.values()) / len(per_replica)
+        print(f"Avg loss: {avg_loss}")
+
+    trainer.save("/tmp/ckpt/", checkpoint_prefix="bert")
 
     trainer.shutdown()
 

--- a/examples/benchmark/utils/ray_utils.py
+++ b/examples/benchmark/utils/ray_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import sys
+import os
+import time
+import ray
+import numpy as np
+import tensorflow as tf
+
+from autodist.strategy import PS, PSLoadBalancing, PartitionedPS, AllReduce, Parallax
+from autodist.ray import TFTrainer, TFRunner
+
+def run_ray_job(strategy,
+                model_fn,
+                loss_fn,
+                model_dir,
+                train_input_fn,
+                steps_per_epoch,
+                steps_per_loop,
+                epochs,
+                sub_model_export_name,
+                custom_callbacks):
+
+    def _get_input_iterator(input_fn, strategy):
+        """Returns distributed dataset iterator."""
+        # When training with TPU pods, datasets needs to be cloned across
+        # workers. Since Dataset instance cannot be cloned in eager mode, we instead
+        # pass callable that returns a dataset.
+        if not callable(input_fn):
+            raise ValueError(
+                '`input_fn` should be a closure that returns a dataset.')
+        if not isinstance(strategy, tf.distribute.Strategy):
+            iterator = tf.compat.v1.data.make_one_shot_iterator(input_fn())
+        else:
+            iterator = iter(
+                strategy.experimental_distribute_datasets_from_function(input_fn))
+        return iterator
+
+    def _replicated_step(model, core_model, inputs):
+        """Replicated training step."""
+        optimizer = model.optimizer
+        use_float16 = isinstance(
+            optimizer, tf.keras.mixed_precision.experimental.LossScaleOptimizer)
+
+        inputs, labels = inputs
+        model_outputs = model(inputs, training=True)
+        loss = loss_fn(labels, model_outputs)
+        if use_float16:
+            scaled_loss = optimizer.get_scaled_loss(loss)
+
+        training_vars = model.trainable_variables
+        if use_float16:
+            scaled_grads = tf.gradients(scaled_loss, training_vars)
+            grads = optimizer.get_unscaled_gradients(scaled_grads)
+        else:
+            grads = tf.gradients(loss, training_vars)
+        train_op = optimizer.apply_gradients(zip(grads, training_vars))
+        return train_op, loss
+
+    def input_fn():
+        return _get_input_iterator(train_input_fn, strategy)
+
+    trainer = TFTrainer(strategy, _replicated_step, model_fn, input_fn)
+
+    for epoch in range(2):
+        per_replica = trainer.train()
+        for host, output in per_replica.items():
+            _, l = output
+            print(f"node:{host}\tloss: {l}")
+
+    trainer.shutdown()
+
+

--- a/examples/linear_regression_ray.py
+++ b/examples/linear_regression_ray.py
@@ -1,14 +1,26 @@
+# Copyright 2021 Petuum, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import sys
 import os
 import time
-
+import ray
 import numpy as np
 import tensorflow as tf
 
-from autodist import AutoDist
 from autodist.strategy import PS, PSLoadBalancing, PartitionedPS, AllReduce, Parallax
-
-import ray
 from autodist.ray import TFTrainer, TFRunner
 
 ray.init(address='auto')
@@ -62,7 +74,7 @@ def train_step(model, inputs, outputs):
 
 
 def main(_):
-    trainer = TFTrainer(Model, data_creator, train_step, PS())
+    trainer = TFTrainer(PS(), Model, data_creator, train_step)
     for epoch in range(EPOCHS):
         trainer.train()
 

--- a/examples/linear_regression_ray.py
+++ b/examples/linear_regression_ray.py
@@ -1,0 +1,214 @@
+import sys
+import os
+import time
+from enum import Enum, auto
+
+import numpy as np
+import tensorflow as tf
+import tensorflow.compat.v1 as v1
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.training.server_lib import ClusterSpec, Server
+
+from autodist import AutoDist
+from autodist.strategy import PS, PSLoadBalancing, PartitionedPS, AllReduce, Parallax
+from autodist.const import ENV, DEFAULT_PORT_RANGE, DEFAULT_WORKING_DIR, DEFAULT_GROUP_LEADER
+from autodist.resource_spec import ResourceSpec
+
+import ray
+
+from ray.cluster_utils import Cluster
+
+ray.init(address='auto')
+
+@ray.remote
+class TFServerActor(object):
+    def launch(self, cluster_spec, job_name, task_index, cpu_device_num):
+        experimental = config_pb2.ConfigProto.Experimental(
+            collective_nccl=False,
+            collective_group_leader=DEFAULT_GROUP_LEADER)
+        s = Server(
+            ClusterSpec(cluster_spec),
+            job_name=job_name,
+            task_index=task_index,
+            config=config_pb2.ConfigProto(
+                experimental=experimental,
+                device_count={"CPU": cpu_device_num},
+                inter_op_parallelism_threads=0,
+                intra_op_parallelism_threads=0,
+                #log_device_placement=True
+            )
+        )
+        s.join()
+
+
+class TFRunner:
+    def __init__(self, model, data_creator, train_step, env, rs):
+        import os
+        for k, v in env.items():
+            if type(v) == bool:
+                os.environ[k] = "True" if v else "False"
+            else:
+                os.environ[k] = v
+
+        self.autodist = AutoDist(resource_spec=rs, strategy_builder=PS())
+        self.g = v1.Graph()
+        with self.g.as_default(), self.autodist.scope():
+            self.fetches = train_step(Model(), *data_creator())
+            self.session = self.autodist.create_distributed_session()
+
+    def step(self):
+        with self.g.as_default(), self.autodist.scope():
+            l, t, b = self.session.run(self.fetches)
+            print('node: {}, loss: {}\nb:{}'.format(self.autodist._cluster.get_local_address(), l, b))
+
+    def _get_strategy_id(self):
+        return self.autodist._
+
+
+class TFTrainer:
+    def __init__(self, model, data_creator, train_step):
+        self._resource_spec = ResourceSpec(resource_info=self._get_resource_info())
+        self._cluster_spec = self._get_default_cluster_spec(self._resource_spec)
+        self._servers = []
+        self._workers = []
+
+        print(self._cluster_spec)
+        for job_name, tasks in self._cluster_spec.items():
+            for task_index, full_address in enumerate(tasks):
+                node_ip, _ = full_address.split(':')
+                server = TFServerActor.options(resources={f"node:{node_ip}": 0.01},
+                                               num_cpus=1).remote()
+                self._servers.append(server)
+                server.launch.remote(self._cluster_spec, job_name, task_index, 1)
+
+        for job_name, tasks in self._cluster_spec.items():
+            for task_index, full_address in enumerate(tasks):
+                node_ip, _ = full_address.split(':')
+                Runner = ray.remote(resources={f"node:{node_ip}": 0.01},
+                                    num_cpus=1)(TFRunner)
+                ischief = node_ip == ray._private.services.get_node_ip_address()
+                env = {
+                    ENV.AUTODIST_WORKER.name: "" if ischief else node_ip,
+                    ENV.AUTODIST_STRATEGY_ID.name: "20210224T233038M775422",
+                    #ENV.AUTODIST_STRATEGY_ID.name: "",
+                    ENV.AUTODIST_MIN_LOG_LEVEL.name: ENV.AUTODIST_MIN_LOG_LEVEL.val,
+                    ENV.AUTODIST_IS_TESTING.name: ENV.AUTODIST_IS_TESTING.val,
+                    ENV.AUTODIST_PATCH_TF.name: ENV.AUTODIST_PATCH_TF.val,
+                    ENV.AUTODIST_INTERNAL_TF.name: ENV.AUTODIST_INTERNAL_TF.val,
+                    ENV.SYS_DATA_PATH.name: ENV.SYS_DATA_PATH.val,
+                    ENV.SYS_RESOURCE_PATH.name: ENV.SYS_RESOURCE_PATH.val,
+                    #'AUTODIST_RESOURCE_SPEC': self._resource_spec,
+                    #'val': property(lambda x: x.value)
+                }
+
+                runner = Runner.remote(model, data_creator, train_step, env, self._resource_spec)
+                self._workers.append(runner)
+
+    @staticmethod
+    def _get_default_cluster_spec(resource_spec: ResourceSpec):
+        """Create list of workers from the resource spec with semi-arbitrarily chosen ports."""
+        return {
+            'worker': [f'{node}:{next(DEFAULT_PORT_RANGE)}'
+                        for node in sorted(resource_spec.nodes, reverse=True)]
+        }
+
+    def _get_resource_info(self):
+        cpu_list = []
+        for node in ray.nodes():
+            node_ip = node["NodeManagerAddress"]
+            cpu_count = node["Resources"].get("CPU")
+            if not cpu_count or not node["Alive"]:
+               continue
+            cpu_list.append((cpu_count, node_ip))
+
+        chief_address = ray._private.services.get_node_ip_address()
+
+        resource_info = {}
+        resource_info["nodes"] = []
+        for cpu_count, node_ip in cpu_list:
+            node = {"address": node_ip, "cpus": [0]}
+            if node_ip == chief_address:
+                node["chief"] = True
+            resource_info["nodes"].append(node)
+        sorted(resource_info["nodes"], key=lambda x: x.get("chief", False))
+        return resource_info
+
+    def train(self):
+        """Runs a training epoch."""
+        ray.get([worker.step.remote() for worker in self._workers])
+
+    def validate(self):
+        pass
+
+    def shutdown(self):
+        for server, worker in zip(self._servers, self._workers):
+            ray.kill(worker)
+            ray.kill(server)
+
+    def save(self):
+        pass
+
+    def restore(self):
+        pass
+
+
+############################################################################
+
+
+EPOCHS = 10
+
+def data_creator():
+    TRUE_W = 3.0
+    TRUE_b = 2.0
+    NUM_EXAMPLES = 1000
+
+    inputs = np.random.randn(NUM_EXAMPLES)
+    noises = np.random.randn(NUM_EXAMPLES)
+    outputs = inputs * TRUE_W + TRUE_b + noises
+
+    class MyIterator:
+        def initialize(self):
+            return tf.zeros(1)
+        def get_next(self):
+            # a fake one
+            return inputs
+    return MyIterator().get_next(), outputs
+
+
+class Model:
+    def __init__(self):
+        self.W = tf.Variable(5.0, name='W', dtype=tf.float64)
+        self.b = tf.Variable(0.0, name='b', dtype=tf.float64)
+
+    def __call__(self, x):
+        return self.W * x + self.b
+
+
+def train_step(model, inputs, outputs):
+    def l(predicted_y, desired_y):
+        return tf.reduce_mean(tf.square(predicted_y - desired_y))
+
+    major_version, _, _ = tf.version.VERSION.split('.')
+    if major_version == '1':
+        optimizer = tf.train.GradientDescentOptimizer(0.01)
+    else:
+        optimizer = tf.optimizers.SGD(0.01)
+
+    loss = l(model(inputs), outputs)
+    vs = [model.W, model.b]
+
+    gradients = tf.gradients(loss, vs)
+
+    train_op = optimizer.apply_gradients(zip(gradients, vs))
+    return loss, train_op, model.b
+
+
+def main(_):
+    trainer = TFTrainer(Model, data_creator, train_step)
+    for epoch in range(EPOCHS):
+        trainer.train()
+
+    trainer.shutdown()
+
+main(sys.argv)
+

--- a/examples/linear_regression_ray.py
+++ b/examples/linear_regression_ray.py
@@ -76,7 +76,10 @@ def train_step(model, inputs, outputs):
 def main(_):
     trainer = TFTrainer(PS(), Model, data_creator, train_step)
     for epoch in range(EPOCHS):
-        trainer.train()
+        per_replica = trainer.train()
+        for host, output in per_replica.items():
+            l, _, b = output
+            print(f"node:{host}\tloss: {l}\tb:{b}")
 
     trainer.shutdown()
 

--- a/examples/linear_regression_ray.py
+++ b/examples/linear_regression_ray.py
@@ -1,159 +1,17 @@
 import sys
 import os
 import time
-from enum import Enum, auto
 
 import numpy as np
 import tensorflow as tf
-import tensorflow.compat.v1 as v1
-from tensorflow.core.protobuf import config_pb2
-from tensorflow.python.training.server_lib import ClusterSpec, Server
 
 from autodist import AutoDist
 from autodist.strategy import PS, PSLoadBalancing, PartitionedPS, AllReduce, Parallax
-from autodist.const import ENV, DEFAULT_PORT_RANGE, DEFAULT_WORKING_DIR, DEFAULT_GROUP_LEADER
-from autodist.resource_spec import ResourceSpec
 
 import ray
-
-from ray.cluster_utils import Cluster
+from autodist.ray import TFTrainer, TFRunner
 
 ray.init(address='auto')
-
-@ray.remote
-class TFServerActor(object):
-    def launch(self, cluster_spec, job_name, task_index, cpu_device_num):
-        experimental = config_pb2.ConfigProto.Experimental(
-            collective_nccl=False,
-            collective_group_leader=DEFAULT_GROUP_LEADER)
-        s = Server(
-            ClusterSpec(cluster_spec),
-            job_name=job_name,
-            task_index=task_index,
-            config=config_pb2.ConfigProto(
-                experimental=experimental,
-                device_count={"CPU": cpu_device_num},
-                inter_op_parallelism_threads=0,
-                intra_op_parallelism_threads=0,
-                #log_device_placement=True
-            )
-        )
-        s.join()
-
-
-class TFRunner:
-    def __init__(self, model, data_creator, train_step, env, rs):
-        import os
-        for k, v in env.items():
-            if type(v) == bool:
-                os.environ[k] = "True" if v else "False"
-            else:
-                os.environ[k] = v
-
-        self.autodist = AutoDist(resource_spec=rs, strategy_builder=PS())
-        self.g = v1.Graph()
-        with self.g.as_default(), self.autodist.scope():
-            self.fetches = train_step(Model(), *data_creator())
-            self.session = self.autodist.create_distributed_session()
-
-    def step(self):
-        with self.g.as_default(), self.autodist.scope():
-            l, t, b = self.session.run(self.fetches)
-            print('node: {}, loss: {}\nb:{}'.format(self.autodist._cluster.get_local_address(), l, b))
-
-    def _get_strategy_id(self):
-        return self.autodist._
-
-
-class TFTrainer:
-    def __init__(self, model, data_creator, train_step):
-        self._resource_spec = ResourceSpec(resource_info=self._get_resource_info())
-        self._cluster_spec = self._get_default_cluster_spec(self._resource_spec)
-        self._servers = []
-        self._workers = []
-
-        print(self._cluster_spec)
-        for job_name, tasks in self._cluster_spec.items():
-            for task_index, full_address in enumerate(tasks):
-                node_ip, _ = full_address.split(':')
-                server = TFServerActor.options(resources={f"node:{node_ip}": 0.01},
-                                               num_cpus=1).remote()
-                self._servers.append(server)
-                server.launch.remote(self._cluster_spec, job_name, task_index, 1)
-
-        for job_name, tasks in self._cluster_spec.items():
-            for task_index, full_address in enumerate(tasks):
-                node_ip, _ = full_address.split(':')
-                Runner = ray.remote(resources={f"node:{node_ip}": 0.01},
-                                    num_cpus=1)(TFRunner)
-                ischief = node_ip == ray._private.services.get_node_ip_address()
-                env = {
-                    ENV.AUTODIST_WORKER.name: "" if ischief else node_ip,
-                    ENV.AUTODIST_STRATEGY_ID.name: "20210224T233038M775422",
-                    #ENV.AUTODIST_STRATEGY_ID.name: "",
-                    ENV.AUTODIST_MIN_LOG_LEVEL.name: ENV.AUTODIST_MIN_LOG_LEVEL.val,
-                    ENV.AUTODIST_IS_TESTING.name: ENV.AUTODIST_IS_TESTING.val,
-                    ENV.AUTODIST_PATCH_TF.name: ENV.AUTODIST_PATCH_TF.val,
-                    ENV.AUTODIST_INTERNAL_TF.name: ENV.AUTODIST_INTERNAL_TF.val,
-                    ENV.SYS_DATA_PATH.name: ENV.SYS_DATA_PATH.val,
-                    ENV.SYS_RESOURCE_PATH.name: ENV.SYS_RESOURCE_PATH.val,
-                    #'AUTODIST_RESOURCE_SPEC': self._resource_spec,
-                    #'val': property(lambda x: x.value)
-                }
-
-                runner = Runner.remote(model, data_creator, train_step, env, self._resource_spec)
-                self._workers.append(runner)
-
-    @staticmethod
-    def _get_default_cluster_spec(resource_spec: ResourceSpec):
-        """Create list of workers from the resource spec with semi-arbitrarily chosen ports."""
-        return {
-            'worker': [f'{node}:{next(DEFAULT_PORT_RANGE)}'
-                        for node in sorted(resource_spec.nodes, reverse=True)]
-        }
-
-    def _get_resource_info(self):
-        cpu_list = []
-        for node in ray.nodes():
-            node_ip = node["NodeManagerAddress"]
-            cpu_count = node["Resources"].get("CPU")
-            if not cpu_count or not node["Alive"]:
-               continue
-            cpu_list.append((cpu_count, node_ip))
-
-        chief_address = ray._private.services.get_node_ip_address()
-
-        resource_info = {}
-        resource_info["nodes"] = []
-        for cpu_count, node_ip in cpu_list:
-            node = {"address": node_ip, "cpus": [0]}
-            if node_ip == chief_address:
-                node["chief"] = True
-            resource_info["nodes"].append(node)
-        sorted(resource_info["nodes"], key=lambda x: x.get("chief", False))
-        return resource_info
-
-    def train(self):
-        """Runs a training epoch."""
-        ray.get([worker.step.remote() for worker in self._workers])
-
-    def validate(self):
-        pass
-
-    def shutdown(self):
-        for server, worker in zip(self._servers, self._workers):
-            ray.kill(worker)
-            ray.kill(server)
-
-    def save(self):
-        pass
-
-    def restore(self):
-        pass
-
-
-############################################################################
-
 
 EPOCHS = 10
 
@@ -204,7 +62,7 @@ def train_step(model, inputs, outputs):
 
 
 def main(_):
-    trainer = TFTrainer(Model, data_creator, train_step)
+    trainer = TFTrainer(Model, data_creator, train_step, PS())
     for epoch in range(EPOCHS):
         trainer.train()
 

--- a/examples/linear_regression_ray.py
+++ b/examples/linear_regression_ray.py
@@ -37,12 +37,15 @@ def data_creator():
     outputs = inputs * TRUE_W + TRUE_b + noises
 
     class MyIterator:
+        def __init__(self, data):
+            self.data = data
         def initialize(self):
             return tf.zeros(1)
         def get_next(self):
             # a fake one
-            return inputs
-    return MyIterator().get_next(), outputs
+            return self.data 
+
+    return MyIterator(inputs), outputs
 
 
 class Model:
@@ -72,9 +75,11 @@ def train_step(model, inputs, outputs):
     train_op = optimizer.apply_gradients(zip(gradients, vs))
     return loss, train_op, model.b
 
+def model_creator():
+    return Model()
 
 def main(_):
-    trainer = TFTrainer(PS(), Model, data_creator, train_step)
+    trainer = TFTrainer(PS(), train_step, model_creator, data_creator)
     for epoch in range(EPOCHS):
         per_replica = trainer.train()
         for host, output in per_replica.items():

--- a/tests/integration/cases/c10.py
+++ b/tests/integration/cases/c10.py
@@ -77,7 +77,7 @@ def main(autodist):
         # Only save the model on master node if autodist is used with NFS.
         checkpoint_suffix = 'c10'
         checkpoint_name = checkpoint_dir + checkpoint_suffix
-        if IS_AUTODIST_CHIEF:
+        if IS_AUTODIST_CHIEF():
             saver.save(session, checkpoint_name, global_step=epoch)
             print('Checkpoint saved at {%s}' % checkpoint_name)
         else:
@@ -85,7 +85,7 @@ def main(autodist):
 
         # check the checkpoint existence only on master node
         checkpoint = checkpoint_name + '-' + str(epoch)
-        if IS_AUTODIST_CHIEF:
+        if IS_AUTODIST_CHIEF():
             assert(os.path.exists(checkpoint + '.meta')) # meta file
             assert(os.path.exists(checkpoint + '.index'))  # meta file
             assert(os.path.exists(checkpoint + '.data-00000-of-00001'))  # meta file


### PR DESCRIPTION
This PR adds RaySGD API to Autodist which enables it to train models on a Ray cluster. The API defines a `TFTrainer` class which takes a model creator, data creator, train step and a strategy builder and runs the training job on a distributed Ray cluster. The API follows the RaySGD API and is compatible with Ray Tune.

```    
trainer = TFTrainer(strategy_builder, model_creator, data_creator, train_step)
trainer.step()
```
Internally it implements a `TFRunner` class which represents a replica. All communication between master and worker replicas happens through in-memory object store so there is no dependance on remote file system locations/accesses rights. Also ssh is not needed. 

Moreover the client code executed by each worker is also replicated using Ray eliminating the need of copying the model code to remote filesystems on each node. The users can run the example by installing Ray and  running `$ python linear_regression_ray.py`.

Reference: https://docs.ray.io/en/master/raysgd/raysgd_tensorflow.html

Fixes #57 